### PR TITLE
docs: use uv and local venv for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ Core files:
 
 ## Setup
 
-Install dependencies:
+Install dependencies with `uv` in a project-local virtual environment:
 
 ```bash
-python3 -m pip install -r requirements.txt
+brew install uv
+uv venv .venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
 ```
 
 Set Advanced Trade credentials in your environment or `.env`:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update setup instructions in `README.md` to use `uv` and a project-local `.venv`
- replace global `pip install -r requirements.txt` with `uv venv .venv`, activation, and `uv pip install -r requirements.txt`
- align onboarding steps with PEP 668-safe installation on macOS/Homebrew Python

## Testing
- docs-only change; no runtime behavior changed
- verified README commands and formatting render correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c10d1bcd-2bd2-461e-a3c6-97aa044b5ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c10d1bcd-2bd2-461e-a3c6-97aa044b5ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

