### PR TITLE
fix: correct Coinbase JWT URI signing and document uv setup

### DIFF
--- a/cbpro.py
+++ b/cbpro.py
@@ -245,16 +245,12 @@ class CoinbaseAdvancedTradeAuth(AuthBase):
 
     def __call__(self, request: requests.PreparedRequest) -> requests.PreparedRequest:
         url = urlsplit(request.url)
-        path_with_query = url.path
-        if url.query:
-            path_with_query = f"{path_with_query}?{url.query}"
-
         payload = {
             "sub": self.api_key,
             "iss": "cdp",
             "nbf": int(time.time()),
             "exp": int(time.time()) + 120,
-            "uri": f"{request.method} {API_HOST}{path_with_query}",
+            "uri": f"{request.method} {API_HOST}{url.path}",
         }
         headers = {
             "alg": "ES256",

--- a/tests/test_cbpro.py
+++ b/tests/test_cbpro.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 from cbpro import (
     CoinbaseAdvancedTradeClient,
+    CoinbaseAdvancedTradeAuth,
     CoinbaseCredentials,
     build_limit_order,
     build_market_order,
@@ -142,6 +143,36 @@ class OrderPayloadTests(unittest.TestCase):
     def test_parse_positive_decimal_rejects_zero(self) -> None:
         with self.assertRaises(ValueError):
             parse_positive_decimal("0")
+
+
+class AuthenticationTests(unittest.TestCase):
+    @patch("cbpro.serialization.load_pem_private_key")
+    @patch("cbpro._build_es256_jwt")
+    def test_rest_jwt_uri_claim_excludes_query_string(
+        self,
+        build_jwt: Mock,
+        load_private_key: Mock,
+    ) -> None:
+        build_jwt.return_value = "signed-token"
+        load_private_key.return_value = Mock()
+        credentials = CoinbaseCredentials(
+            api_key="organizations/test/apiKeys/test",
+            api_secret="-----BEGIN EC PRIVATE KEY-----\nsecret\n-----END EC PRIVATE KEY-----\n",
+        )
+        auth = CoinbaseAdvancedTradeAuth(credentials)
+        request = Mock()
+        request.method = "GET"
+        request.url = "https://api.coinbase.com/api/v3/brokerage/accounts?limit=250&cursor=abc"
+        request.headers = {}
+
+        auth(request)
+
+        payload = build_jwt.call_args.args[0]
+        self.assertEqual(
+            payload["uri"],
+            "GET api.coinbase.com/api/v3/brokerage/accounts",
+        )
+        self.assertEqual(request.headers["Authorization"], "Bearer signed-token")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update setup instructions in `README.md` to use `uv` and a project-local `.venv`
- fix Coinbase Advanced Trade REST JWT signing so the `uri` claim excludes query parameters
- add a regression test covering the authenticated REST `uri` claim format used for balances/account requests

## Testing
- ran `python3 -m unittest discover -s tests -v`
- auth regression test passed
- suite still has unrelated environment failures because `websockets` is not installed in this runner (`test_bot` and `test_webfeed`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c10d1bcd-2bd2-461e-a3c6-97aa044b5ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c10d1bcd-2bd2-461e-a3c6-97aa044b5ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

