### PR TITLE
feat: show live buy fill summary

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import sys
 
 from cbpro import CoinbaseAdvancedTradeClient, CoinbaseBotError, parse_positive_decimal
 from webfeed import CoinbaseWebsocketError, collect_latest_prices
@@ -61,6 +62,40 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def print_live_buy_summary(result: object) -> None:
+    if not isinstance(result, dict):
+        return
+
+    order = result.get("order")
+    if not isinstance(order, dict):
+        return
+
+    filled_size = order.get("filled_size")
+    average_price = order.get("average_filled_price")
+    success_response = result.get("success_response")
+    response_product_id = (
+        success_response.get("product_id")
+        if isinstance(success_response, dict)
+        else None
+    )
+    product_id = order.get("product_id") or response_product_id or "order"
+    status = order.get("status")
+    base_currency, _, quote_currency = str(product_id).partition("-")
+
+    if filled_size and average_price:
+        print(
+            f"Bought {filled_size} {base_currency} at {average_price} {quote_currency} per {base_currency}.",
+            file=sys.stderr,
+        )
+        return
+
+    if status:
+        print(
+            f"Submitted {product_id} buy order; fill details are not available yet.",
+            file=sys.stderr,
+        )
+
+
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
@@ -83,6 +118,7 @@ def main() -> int:
                 )
             client = CoinbaseAdvancedTradeClient.from_env(live_mode=True)
             result = client.place_market_order(args.product_id, funds=args.funds)
+            print_live_buy_summary(result)
         else:
             result = asyncio.run(collect_latest_prices(args.product_ids))
     except (CoinbaseBotError, CoinbaseWebsocketError) as exc:

--- a/cbpro.py
+++ b/cbpro.py
@@ -403,6 +403,14 @@ class CoinbaseAdvancedTradeClient:
             if _decimal(account.get("available_balance", {}).get("value", "0")) > 0
         ]
 
+    def get_order(self, order_id: str) -> dict[str, Any]:
+        response = self._request(
+            "GET",
+            f"orders/historical/{order_id}",
+            auth_required=True,
+        )
+        return response.get("order", {})
+
     def get_product(self, product_id: str) -> dict[str, Any]:
         return self._request("GET", f"market/products/{product_id}")
 
@@ -473,4 +481,9 @@ class CoinbaseAdvancedTradeClient:
                 side="SELL",
                 base_size=sell_size,
             )
-        return self._submit_private_action("POST", "orders", payload)
+        response = self._submit_private_action("POST", "orders", payload)
+        success_response = response.get("success_response", {})
+        order_id = success_response.get("order_id")
+        if self.live_mode and order_id:
+            response["order"] = self.get_order(order_id)
+        return response

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import io
+import json
 import sys
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from unittest.mock import patch
 
 from bot import main
@@ -23,6 +24,75 @@ class BotCliTests(unittest.TestCase):
 
         self.assertEqual(exc.exception.code, 1)
         self.assertIn("--confirm-live", stderr.getvalue())
+
+    @patch("bot.CoinbaseAdvancedTradeClient.from_env")
+    def test_live_buy_prints_fill_summary_and_json(self, from_env) -> None:
+        client = from_env.return_value
+        client.place_market_order.return_value = {
+            "success": True,
+            "success_response": {
+                "order_id": "order-123",
+                "product_id": "BTC-USD",
+            },
+            "order": {
+                "filled_size": "0.001",
+                "average_filled_price": "65000.12",
+            },
+        }
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with patch.object(
+            sys,
+            "argv",
+            ["bot.py", "live-buy", "BTC-USD", "--funds", "10", "--confirm-live"],
+        ):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                result = main()
+
+        self.assertEqual(result, 0)
+        self.assertIn(
+            "Bought 0.001 BTC at 65000.12 USD per BTC.",
+            stderr.getvalue(),
+        )
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            client.place_market_order.return_value,
+        )
+
+    @patch("bot.CoinbaseAdvancedTradeClient.from_env")
+    def test_live_buy_reports_pending_fill_when_details_missing(self, from_env) -> None:
+        client = from_env.return_value
+        client.place_market_order.return_value = {
+            "success": True,
+            "success_response": {
+                "order_id": "order-123",
+                "product_id": "BTC-USD",
+            },
+            "order": {
+                "status": "PENDING",
+            },
+        }
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with patch.object(
+            sys,
+            "argv",
+            ["bot.py", "live-buy", "BTC-USD", "--funds", "10", "--confirm-live"],
+        ):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                result = main()
+
+        self.assertEqual(result, 0)
+        self.assertIn(
+            "Submitted BTC-USD buy order; fill details are not available yet.",
+            stderr.getvalue(),
+        )
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            client.place_market_order.return_value,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cbpro.py
+++ b/tests/test_cbpro.py
@@ -140,6 +140,35 @@ class OrderPayloadTests(unittest.TestCase):
         self.assertEqual(len(balances), 1)
         self.assertEqual(balances[0]["currency"], "BTC")
 
+    def test_live_market_buy_fetches_order_details(self) -> None:
+        client = CoinbaseAdvancedTradeClient(credentials=None, live_mode=True)
+        with patch.object(
+            client,
+            "_submit_private_action",
+            return_value={
+                "success": True,
+                "success_response": {
+                    "order_id": "order-123",
+                    "product_id": "BTC-USD",
+                    "side": "BUY",
+                },
+            },
+        ) as submit_private_action, patch.object(
+            client,
+            "get_order",
+            return_value={
+                "order_id": "order-123",
+                "filled_size": "0.001",
+                "average_filled_price": "65000.00",
+            },
+        ) as get_order:
+            result = client.place_market_order("BTC-USD", funds="10")
+
+        submit_private_action.assert_called_once()
+        get_order.assert_called_once_with("order-123")
+        self.assertEqual(result["success_response"]["order_id"], "order-123")
+        self.assertEqual(result["order"]["filled_size"], "0.001")
+
     def test_parse_positive_decimal_rejects_zero(self) -> None:
         with self.assertRaises(ValueError):
             parse_positive_decimal("0")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fetch order details after a live market buy using the created `order_id`
- print a human-friendly buy summary with filled amount and average fill price when available
- keep the existing JSON output for scripting and add client coverage for the follow-up order lookup

## Testing
- ran `python3 -m unittest tests.test_cbpro -v`
- client-side tests pass, including the new live-buy order detail fetch coverage
- broader CLI tests in this runner still require the optional `websockets` dependency imported by `bot.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c10d1bcd-2bd2-461e-a3c6-97aa044b5ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c10d1bcd-2bd2-461e-a3c6-97aa044b5ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

